### PR TITLE
Add Terraform configuration for vCenter

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -13,6 +13,8 @@
                 - [Accounts](#Accounts)
                 - [ELK Configuration](#ELK-Configuration)
                 - [VM logs configuration](#VM-logs-configuration)
+                - [Terraform Setup](#Terraform-Setup)
+                - [vCenter Configuration](#vCenter-Configuration)
 - [Usage](#Usage)
 	- [Home Page](#home-page-)
 	- [Hunting Page](#hunting-page-)
@@ -172,6 +174,43 @@ sudo VBoxManage snapshot "sandbox" take "Snapshot1" --description "snapshot befo
 
 > ⚠️ After that, and once you've finished configuring the elastic search server, check if the service is running, go to kibana (Hunting page on Purplelab), click on the Discover tab, normally, you will see the Windows event from the VM. 
 Indicators in the home page  should be fed
+
+### Terraform Setup
+
+1. Install Terraform:
+```bash
+sudo apt-get update && sudo apt-get install -y terraform
+```
+
+2. Initialize Terraform:
+```bash
+cd terraform
+terraform init
+```
+
+3. Apply the Terraform configuration:
+```bash
+terraform apply
+```
+
+### vCenter Configuration
+
+1. Ensure you have the necessary vCenter credentials and information:
+   - vSphere user
+   - vSphere password
+   - vSphere server
+   - vSphere datacenter
+   - vSphere datastore
+   - vSphere compute cluster
+   - vSphere network
+   - vSphere template
+
+2. Update the `terraform/variables.tf` file with your vCenter credentials and information.
+
+3. Deploy the infrastructure using Terraform:
+```bash
+terraform apply
+```
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
                 - [Accounts](#Accounts)
                 - [ELK Configuration](#ELK-Configuration)
                 - [VM logs configuration](#VM-logs-configuration)
+                - [Terraform Setup](#Terraform-Setup)
+                - [vCenter Configuration](#vCenter-Configuration)
 - [Usage](#Usage)
 	- [Home Page](#home-page-)
 	- [Hunting Page](#hunting-page-)
@@ -184,6 +186,43 @@ sudo VBoxManage snapshot "sandbox" take "Snapshot1" --description "snapshot befo
 
 > ⚠️ After that, and once you've finished configuring the elastic search server, check if the service is running, go to kibana (Hunting page on Purplelab), click on the Discover tab, normally, you will see the Windows event from the VM. 
 Indicators in the home page  should be fed
+
+### Terraform Setup
+
+1. Install Terraform:
+```bash
+sudo apt-get update && sudo apt-get install -y terraform
+```
+
+2. Initialize Terraform:
+```bash
+cd terraform
+terraform init
+```
+
+3. Apply the Terraform configuration:
+```bash
+terraform apply
+```
+
+### vCenter Configuration
+
+1. Ensure you have the necessary vCenter credentials and information:
+   - vSphere user
+   - vSphere password
+   - vSphere server
+   - vSphere datacenter
+   - vSphere datastore
+   - vSphere compute cluster
+   - vSphere network
+   - vSphere template
+
+2. Update the `terraform/variables.tf` file with your vCenter credentials and information.
+
+3. Deploy the infrastructure using Terraform:
+```bash
+terraform apply
+```
 
 # Usage
 

--- a/Web/app.py
+++ b/Web/app.py
@@ -8,7 +8,9 @@ from logging.handlers import RotatingFileHandler
 import shlex
 from datetime import datetime
 from werkzeug.utils import secure_filename
-
+from pyVim.connect import SmartConnect, Disconnect
+from pyVmomi import vim
+import ssl
 
 app = Flask(__name__)
 
@@ -26,6 +28,15 @@ app.config['JWT_ACCESS_TOKEN_EXPIRES'] = False
 app.config['UPLOAD_FOLDER'] = '/var/www/html/Downloaded/upload/' 
 jwt = JWTManager(app)
 
+# vCenter connection details
+VCENTER_HOST = 'your_vcenter_host'
+VCENTER_USER = 'your_vcenter_user'
+VCENTER_PASSWORD = 'your_vcenter_password'
+
+def connect_to_vcenter():
+    context = ssl._create_unverified_context()
+    si = SmartConnect(host=VCENTER_HOST, user=VCENTER_USER, pwd=VCENTER_PASSWORD, sslContext=context)
+    return si
 
 @app.before_request
 def log_request_info():
@@ -627,6 +638,75 @@ def execute_payload():
             "stderr": e.stderr
         }), 500
 
+@app.route('/vcenter_vms', methods=['GET'])
+@cross_origin()
+def list_vcenter_vms():
+    try:
+        si = connect_to_vcenter()
+        content = si.RetrieveContent()
+        container = content.viewManager.CreateContainerView(content.rootFolder, [vim.VirtualMachine], True)
+        vms = container.view
+        vm_list = [{"name": vm.name, "power_state": vm.runtime.powerState} for vm in vms]
+        Disconnect(si)
+        return jsonify(vm_list), 200
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+@app.route('/vcenter_vm_power', methods=['POST'])
+@cross_origin()
+def vcenter_vm_power():
+    data = request.json
+    vm_name = data.get('vm_name')
+    action = data.get('action')
+
+    if not vm_name or action not in ['poweron', 'poweroff', 'reset']:
+        return jsonify({"error": "Invalid parameters"}), 400
+
+    try:
+        si = connect_to_vcenter()
+        content = si.RetrieveContent()
+        container = content.viewManager.CreateContainerView(content.rootFolder, [vim.VirtualMachine], True)
+        vms = container.view
+        vm = next((vm for vm in vms if vm.name == vm_name), None)
+
+        if not vm:
+            return jsonify({"error": "VM not found"}), 404
+
+        if action == 'poweron':
+            vm.PowerOn()
+        elif action == 'poweroff':
+            vm.PowerOff()
+        elif action == 'reset':
+            vm.Reset()
+
+        Disconnect(si)
+        return jsonify({"message": f"VM {action} action completed successfully"}), 200
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+@app.route('/vcenter_vm_ip', methods=['GET'])
+@cross_origin()
+def vcenter_vm_ip():
+    vm_name = request.args.get('vm_name')
+
+    if not vm_name:
+        return jsonify({"error": "Missing vm_name parameter"}), 400
+
+    try:
+        si = connect_to_vcenter()
+        content = si.RetrieveContent()
+        container = content.viewManager.CreateContainerView(content.rootFolder, [vim.VirtualMachine], True)
+        vms = container.view
+        vm = next((vm for vm in vms if vm.name == vm_name), None)
+
+        if not vm:
+            return jsonify({"error": "VM not found"}), 404
+
+        ip_address = vm.guest.ipAddress
+        Disconnect(si)
+        return jsonify({"ip_address": ip_address}), 200
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
 
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0')

--- a/install.sh
+++ b/install.sh
@@ -506,6 +506,43 @@ sigma plugin install splunk
     sudo mkdir /var/www/html/config/
     sudo chmod 750 /var/www/html/config/
 
+# Install Terraform
+sudo apt-get update && sudo apt-get install -y terraform
+
+# Initialize Terraform
+cd /var/www/html/terraform
+terraform init
+
+# Apply the Terraform configuration
+terraform apply -auto-approve
+
+# Prompt user for vCenter credentials
+read -p "Enter vSphere user: " vsphere_user
+read -sp "Enter vSphere password: " vsphere_password
+echo
+read -p "Enter vSphere server: " vsphere_server
+read -p "Enter vSphere datacenter: " vsphere_datacenter
+read -p "Enter vSphere datastore: " vsphere_datastore
+read -p "Enter vSphere compute cluster: " vsphere_compute_cluster
+read -p "Enter vSphere network: " vsphere_network
+read -p "Enter vSphere template: " vsphere_template
+
+# Update Terraform variables file with vCenter credentials
+cat <<EOF > /var/www/html/terraform/terraform.tfvars
+vsphere_user = "$vsphere_user"
+vsphere_password = "$vsphere_password"
+vsphere_server = "$vsphere_server"
+vsphere_datacenter = "$vsphere_datacenter"
+vsphere_datastore = "$vsphere_datastore"
+vsphere_compute_cluster = "$vsphere_compute_cluster"
+vsphere_network = "$vsphere_network"
+vsphere_template = "$vsphere_template"
+EOF
+
+# Apply the Terraform configuration with the updated variables
+cd /var/www/html/terraform
+terraform apply -auto-approve
+
 SERVER_IP=$(hostname -I | awk '{print $1}')
 
 GREEN='\033[0;32m'

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,112 @@
+provider "vsphere" {
+  user           = var.vsphere_user
+  password       = var.vsphere_password
+  vsphere_server = var.vsphere_server
+
+  # If you have a self-signed cert
+  allow_unverified_ssl = true
+}
+
+data "vsphere_datacenter" "dc" {
+  name = var.vsphere_datacenter
+}
+
+data "vsphere_datastore" "datastore" {
+  name          = var.vsphere_datastore
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_compute_cluster" "cluster" {
+  name          = var.vsphere_compute_cluster
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_network" "network" {
+  name          = var.vsphere_network
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_virtual_machine" "template" {
+  name          = var.vsphere_template
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+resource "vsphere_virtual_machine" "vm" {
+  count            = var.vm_count
+  name             = "${var.vm_name_prefix}-${count.index}"
+  resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
+  datastore_id     = data.vsphere_datastore.datastore.id
+
+  num_cpus = var.vm_num_cpus
+  memory   = var.vm_memory
+  guest_id = data.vsphere_virtual_machine.template.guest_id
+
+  network_interface {
+    network_id   = data.vsphere_network.network.id
+    adapter_type = data.vsphere_virtual_machine.template.network_interface_types[0]
+  }
+
+  disk {
+    label            = "disk0"
+    size             = data.vsphere_virtual_machine.template.disks.0.size
+    eagerly_scrub    = false
+    thin_provisioned = true
+  }
+
+  clone {
+    template_uuid = data.vsphere_virtual_machine.template.id
+
+    customize {
+      linux_options {
+        host_name = "${var.vm_name_prefix}-${count.index}"
+        domain    = var.vm_domain
+      }
+
+      network_interface {
+        ipv4_address = element(var.vm_ip_addresses, count.index)
+        ipv4_netmask = var.vm_netmask
+      }
+
+      ipv4_gateway = var.vm_gateway
+    }
+  }
+}
+
+output "vm_ips" {
+  value = vsphere_virtual_machine.vm.*.network_interface.0.ipv4_address
+}
+
+output "vm_states" {
+  value = vsphere_virtual_machine.vm.*.power_state
+}
+
+variable "vsphere_user" {}
+variable "vsphere_password" {}
+variable "vsphere_server" {}
+variable "vsphere_datacenter" {}
+variable "vsphere_datastore" {}
+variable "vsphere_compute_cluster" {}
+variable "vsphere_network" {}
+variable "vsphere_template" {}
+variable "vm_count" {
+  default = 1
+}
+variable "vm_name_prefix" {
+  default = "vm"
+}
+variable "vm_num_cpus" {
+  default = 2
+}
+variable "vm_memory" {
+  default = 4096
+}
+variable "vm_domain" {
+  default = "local"
+}
+variable "vm_ip_addresses" {
+  type = list(string)
+}
+variable "vm_netmask" {
+  default = 24
+}
+variable "vm_gateway" {}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "vm_ips" {
+  description = "The IP addresses of the VMs"
+  value       = vsphere_virtual_machine.vm.*.network_interface.0.ipv4_address
+}
+
+output "vm_states" {
+  description = "The power states of the VMs"
+  value       = vsphere_virtual_machine.vm.*.power_state
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,71 @@
+variable "vsphere_user" {
+  description = "vSphere user"
+}
+
+variable "vsphere_password" {
+  description = "vSphere password"
+  sensitive   = true
+}
+
+variable "vsphere_server" {
+  description = "vSphere server"
+}
+
+variable "vsphere_datacenter" {
+  description = "vSphere datacenter"
+}
+
+variable "vsphere_datastore" {
+  description = "vSphere datastore"
+}
+
+variable "vsphere_compute_cluster" {
+  description = "vSphere compute cluster"
+}
+
+variable "vsphere_network" {
+  description = "vSphere network"
+}
+
+variable "vsphere_template" {
+  description = "vSphere template"
+}
+
+variable "vm_count" {
+  description = "Number of VMs to create"
+  default     = 1
+}
+
+variable "vm_name_prefix" {
+  description = "Prefix for VM names"
+  default     = "vm"
+}
+
+variable "vm_num_cpus" {
+  description = "Number of CPUs for each VM"
+  default     = 2
+}
+
+variable "vm_memory" {
+  description = "Memory for each VM in MB"
+  default     = 4096
+}
+
+variable "vm_domain" {
+  description = "Domain for VMs"
+  default     = "local"
+}
+
+variable "vm_ip_addresses" {
+  description = "List of IP addresses for VMs"
+  type        = list(string)
+}
+
+variable "vm_netmask" {
+  description = "Netmask for VMs"
+  default     = 24
+}
+
+variable "vm_gateway" {
+  description = "Gateway for VMs"
+}


### PR DESCRIPTION
Add Terraform configuration files and update project files to support vCenter integration.

* **Terraform Configuration:**
  - Add `terraform/main.tf` to define vCenter provider, resources for network and VMs, VM templates, and output variables.
  - Add `terraform/variables.tf` to define variables for vCenter credentials, VM specifications, and network configuration.
  - Add `terraform/outputs.tf` to define output variables for VM IPs and states.

* **Documentation Updates:**
  - Update `README.md` and `Documentation/README.md` to include instructions for Terraform setup and vCenter configuration.

* **Script Updates:**
  - Modify `install.sh` to install Terraform, initialize and apply Terraform configuration, and handle vCenter credentials.

* **API Updates:**
  - Update `Web/app.py` to include API endpoints for managing vCenter VMs, list VMs, power actions, and retrieve VM IPs.
  - Add functions to interact with vCenter using pyVmomi.

